### PR TITLE
Add an ->original copy of the cloned message.

### DIFF
--- a/message_subscribe.module
+++ b/message_subscribe.module
@@ -136,6 +136,8 @@ function message_subscribe_send_message($entity_type, $entity, Message $message,
     // Clone the message in case it will need to be saved, it won't
     // overwrite the existing one.
     $cloned_message = clone $message;
+    // Push a copy of the original message into the new one.
+    $cloned_message->original = $message;
     unset($cloned_message->mid);
     $cloned_message->uid = $uid;
 


### PR DESCRIPTION
It would be nice to be able to access the original message in the message notify stack, specifically the mid, so that it can know what messages are being sent exactly.
