### PR TITLE
Ensure that a missing entity does not lead to a failure

### DIFF
--- a/message_subscribe.module
+++ b/message_subscribe.module
@@ -702,6 +702,10 @@ function message_subscribe_queue_worker($data, $end_time = FALSE) {
   extract($data);
 
   $entity = entity_load_single($entity_type, $entity_id);
+  if (!$entity) {
+    // Abort if the entity could not be loaded to avoid errors.
+    return;
+  }
   if (!$message = message_load($mid)) {
     // Abort if the message has been deleted to avoid errors.
     return;


### PR DESCRIPTION
<h3 id="summary-problem-motivation">Problem/Motivation</h3>


We have seen some entries in the logs which look like the following:

<code>
string(1192) "#0 /var/www/html-dev/sites/all/modules/contrib/message_subscribe/message_subscribe.module(89): entity_extract_ids('comment', false)
</code>

This for example can happen if you delete a comment, while its going to be proceeded in the meantime.

<h3 id="summary-proposed-resolution">Proposed resolution</h3>


Let's built some protection against such errors.

<h3 id="summary-remaining-tasks">Remaining tasks</h3>


<h3 id="summary-ui-changes">User interface changes</h3>


<h3 id="summary-api-changes">API changes</h3>
