### PR TITLE
"last uid" is not respected when range and list of user IDs is provided.

### DIFF
--- a/message_subscribe.module
+++ b/message_subscribe.module
@@ -130,7 +130,16 @@ function message_subscribe_send_message($entity_type, $entity, Message $message,
   if ($subscribe_options['uids']) {
     // We got a list of user IDs directly from the implementing module,
     // However we need to adhere to the range.
-    $uids = $subscribe_options['range'] ? array_slice($subscribe_options['uids'], 0, $subscribe_options['range'], TRUE) : $subscribe_options['uids'];
+    // If 'last uid' is provided, we need to start from next 'uid' key in array.
+    if (!empty($subscribe_options['last uid'])) {
+      $index = array_search($subscribe_options['last uid'], array_keys($subscribe_options['uids'])) + 1;
+    }
+    // Otherwise we start from the very beginning.
+    else {
+      $index = 0;
+    }
+
+    $uids = $subscribe_options['range'] ? array_slice($subscribe_options['uids'], $index, $subscribe_options['range'], TRUE) : $subscribe_options['uids'];
   }
 
   if (empty($uids) && !$uids = message_subscribe_get_subscribers($entity_type, $entity, $message, $subscribe_options, $context)) {

--- a/message_subscribe.test
+++ b/message_subscribe.test
@@ -521,4 +521,47 @@ class MessageSubscribeQueueTest extends DrupalWebTestCase {
     $this->cronRun();
     $this->assertEqual($queue->numberOfItems(), 0, 'Message item 2 processed by cron.');
   }
+
+  /**
+   * Test that if we get a list of user IDs directly from
+   * the implementing module, the messages are sent respecting
+   * the range value.
+   */
+  function testProvidedUserIdsAreSplitAccordingToRangeValue() {
+
+    $user1 = $this->drupalCreateUser();
+    $user2 = $this->drupalCreateUser();
+    $user3 = $this->drupalCreateUser();
+
+    $message = message_create('foo', array());
+
+    $subscribe_options = array(
+      'uids' => array(
+        $user1->uid => array('notifiers' => array('email')),
+        $user2->uid => array('notifiers' => array('email')),
+        $user3->uid => array('notifiers' => array('email')),
+      ),
+      'skip context' => TRUE,
+      'range' => 1,
+      'last uid' => $user1->uid,
+    );
+
+    message_subscribe_send_message('node', $this->node, $message, array(), $subscribe_options);
+
+    // Run cron.
+    $this->cronRun();
+
+    $captured_emails = variable_get('drupal_test_email_collector', array());
+    $this->assertEqual(2, count($captured_emails), 'The amount of recipients is the same as amount of emails captured according to "subscribe_options".');
+
+    $recipients = array();
+    foreach ($captured_emails as $captured_email) {
+      $recipients[] = $captured_email['to'];
+    }
+
+    $this->assertFalse(in_array($user1->mail, $recipients), 'User 1 mail is not in the recipient list as it was defined as "last uid".');
+    $this->assertTrue(in_array($user2->mail, $recipients), 'User 2 mail is in the recipient list.');
+    $this->assertTrue(in_array($user3->mail, $recipients), 'User 3 mail is in the recipient list.');
+  }
+
 }


### PR DESCRIPTION
Message subscribe does not use "last uid" at all when the list of user IDs is provided and range is enabled in subscribe options.
https://www.drupal.org/node/2256899
