### PR TITLE
Fix uninstall.

### DIFF
--- a/message_subscribe.install
+++ b/message_subscribe.install
@@ -11,8 +11,8 @@
  * Delete default_notifiers variable from the database.
  */
 function message_subscribe_uninstall() {
-  \Drupal::config('message_subscribe.settings')->clear('default_notifiers')->save();
-  \Drupal::config('message_subscribe.settings')->clear('flag_prefix')->save();
-  \Drupal::config('message_subscribe.settings')->clear('use_queue')->save();
-  \Drupal::config('message_subscribe.settings')->clear('notify_own_actions')->save();
+  \Drupal::configFactory()->getEditable('message_subscribe.settings')->clear('default_notifiers')->save();
+  \Drupal::configFactory()->getEditable('message_subscribe.settings')->clear('flag_prefix')->save();
+  \Drupal::configFactory()->getEditable('message_subscribe.settings')->clear('use_queue')->save();
+  \Drupal::configFactory()->getEditable('message_subscribe.settings')->clear('notify_own_actions')->save();
 }


### PR DESCRIPTION
Uninstalling the module in Drupal 8 was causing:

> Drupal\Core\Config\ImmutableConfigException: Can not clear               [error]
> 
> default_notifiers key in immutable configuration
> message_subscribe.settings. Use
> \Drupal\Core\Config\ConfigFactoryInterface::getEditable() to retrieve
> a mutable configuration object in
> C:\Users\epu000005\Sites\devdesktop\pes-dev\core\lib\Drupal\Core\Config\Immutabl
> eConfig.php:34
> Stack trace:
> # 0
> 
> C:\Users\epu000005\Sites\devdesktop\pes-dev\modules\message_subscribe\message_su
> bscribe.install(14):

So (hopefully) here is the fix.
