### PR TITLE
MessageType is now MessageTemplate.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ before_script:
   # Download dependencies.
   # @todo Specify in `require` and `require-dev` in `composer.json`
   - cd modules
-  - travis_retry git clone --branch 8.x-1.x --depth 1 https://github.com/amitaibu/og.git
+  - travis_retry git clone --branch 8.x-1.x --depth 1 https://github.com/Gizra/og.git
   - travis_retry git clone --branch 8.x-4.x --depth 1 https://git.drupal.org/project/flag.git
   - travis_retry git clone --branch 8.x-1.x --depth 1 https://github.com/Gizra/message.git
   - travis_retry git clone --branch 8.x-1.x --depth 1 https://github.com/Gizra/message_notify.git

--- a/config/schema/message_subscribe.schema.yml
+++ b/config/schema/message_subscribe.schema.yml
@@ -17,3 +17,11 @@ message_subscribe.settings:
       sequence:
         type: string
         label: 'Message notifier'
+
+flag.flag.*.third_party.message_subscribe_ui:
+  type: mapping
+  label: 'Message subscribe settings'
+  mapping:
+    view_name:
+      type: string
+      label: 'View name'

--- a/message_subscribe.api.php
+++ b/message_subscribe.api.php
@@ -1,6 +1,5 @@
 <?php
 
-
 /**
  * @file
  * Hooks provided by the Message subscribe module.

--- a/message_subscribe.services.yml
+++ b/message_subscribe.services.yml
@@ -2,3 +2,5 @@ services:
   message_subscribe.subscribers:
     class: \Drupal\message_subscribe\Subscribers
     arguments: ['@flag', '@config.factory', '@entity_type.manager', '@message_notify.sender', '@module_handler', '@queue']
+    calls:
+      - [setMembershipManager, ['@?og.membership_manager']]

--- a/message_subscribe_email/message_subscribe_email.views_default.inc
+++ b/message_subscribe_email/message_subscribe_email.views_default.inc
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @file
  * message_subscribe_email.views_default.inc

--- a/message_subscribe_email/tests/src/Kernel/MessageSubscribeEmailNotificationsTest.php
+++ b/message_subscribe_email/tests/src/Kernel/MessageSubscribeEmailNotificationsTest.php
@@ -24,7 +24,7 @@ class MessageSubscribeEmailNotificationsTest extends MessageSubscribeEmailTestBa
    * Test opting in/out of default email notifications.
    */
   public function testEmailNotifications() {
-    $message = Message::create(['type' => $this->messageType->id()]);
+    $message = Message::create(['template' => $this->messageTemplate->id()]);
 
     $node = $this->nodes[1];
     $user1 = $this->users[1];

--- a/message_subscribe_email/tests/src/Kernel/MessageSubscribeEmailNotificationsTest.php
+++ b/message_subscribe_email/tests/src/Kernel/MessageSubscribeEmailNotificationsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Drupal\Tests\message_subscribe_email\Kernel;
 
 use Drupal\message\Entity\Message;

--- a/message_subscribe_email/tests/src/Kernel/MessageSubscribeEmailSubscribersTest.php
+++ b/message_subscribe_email/tests/src/Kernel/MessageSubscribeEmailSubscribersTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Drupal\Tests\message_subscribe_email\Kernel;
 
 use Drupal\Core\Test\AssertMailTrait;

--- a/message_subscribe_email/tests/src/Kernel/MessageSubscribeEmailSubscribersTest.php
+++ b/message_subscribe_email/tests/src/Kernel/MessageSubscribeEmailSubscribersTest.php
@@ -1,5 +1,6 @@
 <?php
 namespace Drupal\Tests\message_subscribe_email\Kernel;
+
 use Drupal\Core\Test\AssertMailTrait;
 use Drupal\message\Entity\Message;
 
@@ -34,7 +35,7 @@ class MessageSubscribeEmailSubscribersTest extends MessageSubscribeEmailTestBase
    * Test getting the subscribers list.
    */
   public function testGetSubscribers() {
-    $message = Message::create(['type' => $this->messageType->id()]);
+    $message = Message::create(['template' => $this->messageTemplate->id()]);
 
     $node = $this->nodes[1];
     $user1 = $this->users[1];
@@ -70,7 +71,7 @@ class MessageSubscribeEmailSubscribersTest extends MessageSubscribeEmailTestBase
     // Assert sent emails.
     $mails = $this->getMails();
     $this->assertEquals(1, count($mails), 'Only one user was sent an email.');
-    $this->assertEquals('message_notify_' . $this->messageType->id(), $mails[0]['id']);
+    $this->assertEquals('message_notify_' . $this->messageTemplate->id(), $mails[0]['id']);
   }
 
 }

--- a/message_subscribe_email/tests/src/Kernel/MessageSubscribeEmailTestBase.php
+++ b/message_subscribe_email/tests/src/Kernel/MessageSubscribeEmailTestBase.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\Tests\message_subscribe_email\Kernel;
 
-use Drupal\message\Entity\MessageType;
+use Drupal\message\Entity\MessageTemplate;
 use Drupal\Tests\message_subscribe\Kernel\MessageSubscribeTestBase;
 
 /**
@@ -24,11 +24,11 @@ abstract class MessageSubscribeEmailTestBase extends MessageSubscribeTestBase {
   protected $flagService;
 
   /**
-   * Message type.
+   * Message template.
    *
-   * @var \Drupal\message\MessageTypeInterface
+   * @var \Drupal\message\MessageTemplateInterface
    */
-  protected $messageType;
+  protected $messageTemplate;
 
   /**
    * Nodes to test with.
@@ -86,8 +86,8 @@ abstract class MessageSubscribeEmailTestBase extends MessageSubscribeTestBase {
     $this->nodes[1] = $this->createNode($settings);
 
     // Create a dummy message-type.
-    $this->messageType = MessageType::create(['type' => 'foo']);
-    $this->messageType->save();
+    $this->messageTemplate = MessageTemplate::create(['template' => 'foo']);
+    $this->messageTemplate->save();
 
     $this->config('message_subscribe.settings')
       // Override default notifiers.

--- a/src/Subscribers.php
+++ b/src/Subscribers.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Drupal\message_subscribe;
+
 use Drupal\comment\CommentInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Entity\EntityInterface;
@@ -13,7 +14,6 @@ use Drupal\message\MessageInterface;
 use Drupal\message_notify\MessageNotifier;
 use Drupal\message_subscribe\Exception\MessageSubscribeException;
 use Drupal\og\MembershipManagerInterface;
-use Drupal\og\Og;
 use Drupal\user\EntityOwnerInterface;
 
 /**

--- a/src/Subscribers.php
+++ b/src/Subscribers.php
@@ -12,6 +12,7 @@ use Drupal\flag\FlagServiceInterface;
 use Drupal\message\MessageInterface;
 use Drupal\message_notify\MessageNotifier;
 use Drupal\message_subscribe\Exception\MessageSubscribeException;
+use Drupal\og\MembershipManagerInterface;
 use Drupal\og\Og;
 use Drupal\user\EntityOwnerInterface;
 
@@ -56,6 +57,15 @@ class Subscribers implements SubscribersInterface {
   protected $moduleHandler;
 
   /**
+   * The group membership manager service.
+   *
+   * This is only available if the OG module is enabled.
+   *
+   * @var \Drupal\og\MembershipManagerInterface
+   */
+  protected $membershipManager;
+
+  /**
    * The message subscribe queue.
    *
    * @var \Drupal\Core\Queue\QueueInterface
@@ -85,6 +95,16 @@ class Subscribers implements SubscribersInterface {
     $this->messageNotifier = $message_notifier;
     $this->moduleHandler = $module_handler;
     $this->queue = $queue->get('message_subscribe');
+  }
+
+  /**
+   * Set the group membership manager service.
+   *
+   * @param \Drupal\og\MembershipManagerInterface $membership_manager
+   *   The group membership manager service.
+   */
+  public function setMembershipManager(MembershipManagerInterface $membership_manager) {
+    $this->membershipManager = $membership_manager;
   }
 
   /**
@@ -322,7 +342,7 @@ class Subscribers implements SubscribersInterface {
     if ($this->moduleHandler->moduleExists('og')) {
       // Iterate over existing nodes to extract the related groups.
       foreach ($nodes as $node) {
-        foreach (Og::getGroupIds($node) as $group_type => $gids) {
+        foreach ($this->membershipManager->getGroupIds($node) as $group_type => $gids) {
           foreach ($gids as $gid) {
             $context[$group_type][$gid] = $gid;
           }

--- a/src/SubscribersInterface.php
+++ b/src/SubscribersInterface.php
@@ -57,6 +57,7 @@ interface SubscribersInterface {
    *   itself, the node author and related taxonomy terms.
    *
    *   Example usage.
+   *
    * @code
    *   $subscribe_options['uids'] = array(
    *     1 => array(

--- a/tests/src/Kernel/ContextTest.php
+++ b/tests/src/Kernel/ContextTest.php
@@ -93,7 +93,7 @@ class ContextTest extends MessageSubscribeTestBase {
     // Create group node-type.
     $type = $this->createContentType();
     $group_type = $type->id();
-    Og::groupManager()->addGroup('node', $group_type);
+    Og::groupTypeManager()->addGroup('node', $group_type);
 
     // Create node-type.
     $type = $this->createContentType();

--- a/tests/src/Kernel/ContextTest.php
+++ b/tests/src/Kernel/ContextTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Drupal\Tests\message_subscribe\Kernel;
 
 use Drupal\comment\CommentInterface;

--- a/tests/src/Kernel/QueueTest.php
+++ b/tests/src/Kernel/QueueTest.php
@@ -3,7 +3,7 @@
 namespace Drupal\Tests\message_subscribe\Kernel;
 
 use Drupal\message\Entity\Message;
-use Drupal\message\Entity\MessageType;
+use Drupal\message\Entity\MessageTemplate;
 use Drupal\message_subscribe\Exception\MessageSubscribeException;
 
 /**
@@ -36,8 +36,8 @@ class QueueTest extends MessageSubscribeTestBase {
     $this->messageSubscribers = $this->container->get('message_subscribe.subscribers');
 
     // Create a dummy message-type.
-    $message_type = MessageType::create([
-      'type' => 'foo',
+    $message_type = MessageTemplate::create([
+      'template' => 'foo',
       'message_text' => [
         'value' => 'Example text.',
       ],
@@ -62,7 +62,7 @@ class QueueTest extends MessageSubscribeTestBase {
   public function testQueue() {
     $node = $this->node;
     $message = Message::create([
-      'type' => 'foo',
+      'template' => 'foo',
     ]);
 
     $subscribe_options = [];
@@ -118,7 +118,7 @@ class QueueTest extends MessageSubscribeTestBase {
    */
   public function testQueueCron() {
     $node = $this->node;
-    $message = Message::create(['type' => 'foo']);
+    $message = Message::create(['template' => 'foo']);
     $queue = \Drupal::queue('message_subscribe');
 
     // Start with a control case.

--- a/tests/src/Kernel/SubscribersTest.php
+++ b/tests/src/Kernel/SubscribersTest.php
@@ -4,7 +4,7 @@ namespace Drupal\Tests\message_subscribe\Kernel;
 
 use Drupal\Core\Session\AccountInterface;
 use Drupal\message\Entity\Message;
-use Drupal\message\Entity\MessageType;
+use Drupal\message\Entity\MessageTemplate;
 use Drupal\simpletest\NodeCreationTrait;
 
 /**
@@ -113,8 +113,8 @@ class SubscribersTest extends MessageSubscribeTestBase {
     $this->flagService->flag($flags['subscribe_user'], $this->users[1], $this->users[2]);
 
     // Create a dummy message-type.
-    $message_type = MessageType::create([
-      'type' => 'foo',
+    $message_type = MessageTemplate::create([
+      'template' => 'foo',
       'message_text' => ['value' => 'Example text.'],
     ]);
     $message_type->save();
@@ -128,7 +128,7 @@ class SubscribersTest extends MessageSubscribeTestBase {
    */
   public function testGetSubscribers() {
     $message = Message::create([
-      'type' => 'foo',
+      'template' => 'foo',
       'uid' => $this->users[1],
     ]);
 
@@ -153,7 +153,7 @@ class SubscribersTest extends MessageSubscribeTestBase {
 
     // Test none of users will get message if only blocked user is subscribed.
     $message = Message::create([
-      'type' => 'foo',
+      'template' => 'foo',
       'uid' => $this->users[1],
     ]);
 
@@ -222,7 +222,7 @@ class SubscribersTest extends MessageSubscribeTestBase {
     // Test the affect of the variable when set to FALSE (do not notify self).
     \Drupal::configFactory()->getEditable('message_subscribe.settings')->set('notify_own_actions', FALSE)->save();
     $message = Message::create([
-      'type' => 'foo',
+      'template' => 'foo',
       'uid' => $this->users[1],
     ]);
 
@@ -275,7 +275,7 @@ class SubscribersTest extends MessageSubscribeTestBase {
     // Make sure we are notifying ourselves for this test.
     \Drupal::configFactory()->getEditable('message_subscribe.settings')->set('notify_own_actions', TRUE)->save();
 
-    $message = Message::create(['type' => 'foo']);
+    $message = Message::create(['template' => 'foo']);
 
     $node = $this->nodes[0];
     $node->setPublished(FALSE);
@@ -304,7 +304,7 @@ class SubscribersTest extends MessageSubscribeTestBase {
     $this->enableModules(['message_subscribe_test']);
 
     $message = Message::create([
-      'type' => 'foo',
+      'template' => 'foo',
       'uid' => $this->users[1],
     ]);
 


### PR DESCRIPTION
- Also contains an unrelated schema fix that was causing some tests to
  fail.

This depends on https://github.com/Gizra/message_notify/pull/25, so tests will not pass until that is in.
