### PR TITLE
Content type subscriptions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,13 @@ before_script:
   - travis_retry git clone --branch 8.x-1.x --depth 1 https://github.com/Gizra/message_notify.git
   - cd ..
 
+  # Patch Flag for Config Entity flaggings.
+  # @todo Remove once https://www.drupal.org/node/2678756 is committed.
+  - cd modules/flag
+  - curl https://www.drupal.org/files/issues/2678756-20.patch > patch.txt
+  - git apply patch.txt && rm patch.txt
+  - cd -
+
   # Install Composer dependencies on 8.1.x and above.
   - test ${DRUPAL_CORE} == "8.0.x" || composer self-update && composer install
 

--- a/config/optional/flag.flag.subscribe_node_type.yml
+++ b/config/optional/flag.flag.subscribe_node_type.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies: {  }
+id: subscribe_node_type
+label: 'Content type'
+bundles: {  }
+entity_type: node_type
+enabled: false
+global: false
+weight: 0
+flag_short: Subscribe
+flag_long: ''
+flag_message: 'You are now subscribed to this content type.'
+unflag_short: Unsubscribe
+unflag_long: ''
+unflag_message: 'You are no longer subscribed to this content type.'
+unflag_denied_text: ''
+flag_type: 'entity:node_type'
+link_type: ajax_link
+flagTypeConfig:
+  show_in_links: {  }
+  show_as_field: 1
+  show_on_form: 0
+  show_contextual_link: 0
+linkTypeConfig: {  }
+

--- a/message_subscribe_ui/src/Plugin/Derivative/MessageSubscribeUiLocalTask.php
+++ b/message_subscribe_ui/src/Plugin/Derivative/MessageSubscribeUiLocalTask.php
@@ -3,6 +3,7 @@
 namespace Drupal\message_subscribe_ui\Plugin\Derivative;
 
 use Drupal\Component\Plugin\Derivative\DeriverBase;
+use Drupal\Core\Entity\ContentEntityTypeInterface;
 use Drupal\Core\Plugin\Discovery\ContainerDeriverInterface;
 use Drupal\message_subscribe\SubscribersInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -46,6 +47,12 @@ class MessageSubscribeUiLocalTask extends DeriverBase implements ContainerDerive
 
     $first = TRUE;
     foreach ($this->subscribers->getFlags() as $flag) {
+      // @todo Remove this once config entities can have views with
+      // relationships.
+      if (!\Drupal::entityTypeManager()->getDefinition($flag->getFlaggableEntityTypeId()) instanceof ContentEntityTypeInterface) {
+        continue;
+      }
+
       $this->derivatives[$flag->id()] = [
         'title' => $flag->label(),
         // First route gets the same route name as the parent (in order to


### PR DESCRIPTION
- Starts on #31
- Excludes any Views, as config entities do not readily work with Views

This is a work in progress, as when I dug deeper, the Views portion will just not be doable at this time. While there are [Config Views](https://www.drupal.org/project/config_views), they do not support relationships to flaggings, and it felt like a rabbit hole.

We could merge just this bit, or move it to an example module. Alternatively, it wouldn't be too hard to write a non-view tab controller that would show a user their subscribed content types, and flags for ones they were not subscribed to.
