### PR TITLE
Unset email notifier before adding for subscribers

### DIFF
--- a/message_subscribe_email/message_subscribe_email.module
+++ b/message_subscribe_email/message_subscribe_email.module
@@ -61,10 +61,15 @@ function message_subscribe_email_message_subscribe_get_subscribers_alter(array &
     ->condition('uid', array_keys($uids), 'IN')
     ->groupBy('uid')
     ->execute()
-    ->fetchAll();
+    ->fetchAllAssoc('uid');
 
-  foreach ($result as $row) {
-    // Add 'email' to the list of notifiers.
-    $uids[$row->uid]['notifiers']['email'] = 'email';
+  foreach ($uids as $uid => $data) {
+    if (!in_array($uid, array_keys($result))) {
+      unset($uids[$uid]['notifiers']['email']);
+    }
+    else {
+      // Ensure the email notifier is set for email subscribers.
+      $uids[$uid]['notifiers']['email'] = 'email';
+    }
   }
 }

--- a/message_subscribe_email/tests/src/Kernel/MessageSubscribeEmailSubscribersTest.php
+++ b/message_subscribe_email/tests/src/Kernel/MessageSubscribeEmailSubscribersTest.php
@@ -103,9 +103,7 @@ class MessageSubscribeEmailSubscribersTest extends MessageSubscribeEmailTestBase
         ],
       ],
       $user2->id() => [
-        'notifiers' => [
-          'email' => 'email',
-        ],
+        'notifiers' => [],
         'flags' => [
           'subscribe_node',
         ],
@@ -121,7 +119,7 @@ class MessageSubscribeEmailSubscribersTest extends MessageSubscribeEmailTestBase
 
     // Assert sent emails.
     $mails = $this->getMails();
-    $this->assertEquals(2, count($mails), 'Both users were sent an email.');
+    $this->assertEquals(1, count($mails), 'Only user 1 was sent an email.');
     $this->assertEquals('message_notify_' . $this->messageTemplate->id(), $mails[0]['id']);
   }
 


### PR DESCRIPTION
- Fixes #30 

There's probably a better way to loop through and unset these...
