### PR TITLE
Surface view cache tags on subscription tabs.

### DIFF
--- a/message_subscribe_email/tests/src/Functional/ViewsTest.php
+++ b/message_subscribe_email/tests/src/Functional/ViewsTest.php
@@ -108,6 +108,7 @@ class ViewsTest extends BrowserTestBase {
     $flag = $this->flagService->getFlagById('subscribe_node');
     $this->flagService->flag($flag, $node, $users[2]);
     $this->drupalGet('user/' . $users[2]->id() . '/message-subscribe/subscribe_node');
+    // The node title (label) appears on the list of subscribed content.
     $this->assertSession()->pageTextContains($node->label());
     $this->assertSession()->pageTextContains(t("Don't send email"));
 
@@ -117,6 +118,16 @@ class ViewsTest extends BrowserTestBase {
     $this->drupalGet('user/' . $users[2]->id() . '/message-subscribe/subscribe_user');
     $this->assertSession()->pageTextContains($users[1]->label());
     $this->assertSession()->pageTextContains(t("Don't send email"));
+
+    // Login user 3.
+    $this->drupalLogin($users[3]);
+    $this->drupalGet('user/' . $users[3]->id() . '/message-subscribe');
+    $this->assertSession()->pageTextContains(t('You are not subscribed to any items.'));
+    $flag = $this->flagService->getFlagById('subscribe_node');
+    $this->flagService->flag($flag, $node, $users[3]);
+    $this->drupalGet('user/' . $users[3]->id() . '/message-subscribe');
+    // The node title (label) appears on the list of subscribed content.
+    $this->assertSession()->pageTextContains($node->label());
   }
 
 }

--- a/message_subscribe_ui/src/Controller/SubscriptionController.php
+++ b/message_subscribe_ui/src/Controller/SubscriptionController.php
@@ -152,8 +152,8 @@ class SubscriptionController extends ControllerBase {
     $view = $this->getView($user, $flag);
     $result = $view->preview();
 
-    // Add cache tags for this flag.
-    $result['#cache']['tags'] = $flag->getCacheTags();
+    // Add cache tags for this flag and view.
+    $result['#cache']['tags'] = $flag->getCacheTags() + $view->getCacheTags();
     return $result;
   }
 


### PR DESCRIPTION
- Fixes #50 
- Includes a test to demonstrate issue/fix.