### PR TITLE
Fix call to undefined method due to changes in the Flag module

### DIFF
--- a/src/Subscribers.php
+++ b/src/Subscribers.php
@@ -319,7 +319,7 @@ class Subscribers implements SubscribersInterface {
    * {@inheritdoc}
    */
   public function getFlags($entity_type = NULL, $bundle = NULL, AccountInterface $account = NULL) {
-    $flags = $this->flagService->getFlags($entity_type, $bundle, $account);
+    $flags = $this->flagService->getAllFlags($entity_type, $bundle, $account);
     $ms_flags = [];
     $prefix = $this->config->get('flag_prefix') . '_';
     foreach ($flags as $flag_name => $flag) {


### PR DESCRIPTION
This issue…

https://www.drupal.org/node/2813725

…splits getFlags() into getAllFlags() and getUsersFlags() leaving a method that message_subscribe calls that no longer exists and a fatal error.

Fatal error: Call to undefined method Drupal\flag\FlagService::getFlags() in /modules/contrib/message_subscribe/src/Subscribers.php on line 322

Offering a basic patch that works around the fatal error.