### PR TITLE
Assumption that all entities have uid authors causes notices to block queue

### DIFF
--- a/message_subscribe.module
+++ b/message_subscribe.module
@@ -259,7 +259,7 @@ function message_subscribe_get_subscribers($entity_type, $entity, Message $messa
   }
 
   // See if the author of the entity gets notified.
-  if (!$notify_message_owner && array_key_exists ($entity->uid , $uids)) {
+  if (isset($entity->uid) && !$notify_message_owner && array_key_exists($entity->uid, $uids)) {
     unset($uids[$entity->uid]);
   }
 


### PR DESCRIPTION
https://www.drupal.org/node/2846159#comment-11882709
