### PR TITLE
Rename property for original message.

### DIFF
--- a/src/Subscribers.php
+++ b/src/Subscribers.php
@@ -184,8 +184,11 @@ class Subscribers implements SubscribersInterface {
       // Clone the message in case it will need to be saved, it won't
       // overwrite the existing one.
       $cloned_message = $message->createDuplicate();
-      // Push a copy of the original message into the new one.
-      $cloned_message->original = $message;
+      // Push a copy of the original message into the new one. The key
+      // `original` is not used here as that has special meaning and can prevent
+      // field values from being saved.
+      // @see SqlContentEntityStorage::saveToDedicatedTables().
+      $cloned_message->original_message = $message;
       // Set the owner to this user.
       $cloned_message->setOwnerId($delivery_candidate->getAccountId());
 


### PR DESCRIPTION
- Fixes #84.

This actually had nothing to do with the message being unsaved. Rather, the `original` property of an entity takes on special meaning in `SqlContentEntityStorage::saveToDedicatedTables()`, where it checks to see if field values have changed. Since this is a clone, most of the time those values have not changed, and therefor were not being written to the db.