### PR TITLE
Adding a reference from the email flagging to the subscribe flagging.

### DIFF
--- a/message_subscribe_email/config/optional/field.field.flagging.email_node.subscribe_flagging.yml
+++ b/message_subscribe_email/config/optional/field.field.flagging.email_node.subscribe_flagging.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.subscribe_flagging
+    - flag.flag.email_node
+id: flagging.email_node.subscribe_flagging
+field_name: subscribe_flagging
+entity_type: flagging
+bundle: email_node
+label: 'Subscription flagging'
+description: 'The subscribe flagging that this is tied to.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:flagging'
+  handler_settings: {  }
+field_type: entity_reference

--- a/message_subscribe_email/config/optional/field.field.flagging.email_og.subscribe_flagging.yml
+++ b/message_subscribe_email/config/optional/field.field.flagging.email_og.subscribe_flagging.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.subscribe_flagging
+    - flag.flag.email_og
+id: flagging.email_og.subscribe_flagging
+field_name: subscribe_flagging
+entity_type: flagging
+bundle: email_og
+label: 'Subscription flagging'
+description: 'The subscribe flagging that this is tied to.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:flagging'
+  handler_settings: {  }
+field_type: entity_reference

--- a/message_subscribe_email/config/optional/field.field.flagging.email_term.subscribe_flagging.yml
+++ b/message_subscribe_email/config/optional/field.field.flagging.email_term.subscribe_flagging.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.subscribe_flagging
+    - flag.flag.email_term
+id: flagging.email_term.subscribe_flagging
+field_name: subscribe_flagging
+entity_type: flagging
+bundle: email_term
+label: 'Subscription flagging'
+description: 'The subscribe flagging that this is tied to.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:flagging'
+  handler_settings: {  }
+field_type: entity_reference

--- a/message_subscribe_email/config/optional/field.field.flagging.email_user.subscribe_flagging.yml
+++ b/message_subscribe_email/config/optional/field.field.flagging.email_user.subscribe_flagging.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.flagging.subscribe_flagging
+    - flag.flag.email_user
+id: flagging.email_user.subscribe_flagging
+field_name: subscribe_flagging
+entity_type: flagging
+bundle: email_user
+label: 'Subscription flagging'
+description: 'The subscribe flagging that this is tied to.'
+required: true
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:flagging'
+  handler_settings: {  }
+field_type: entity_reference

--- a/message_subscribe_email/config/optional/field.storage.flagging.subscribe_flagging.yml
+++ b/message_subscribe_email/config/optional/field.storage.flagging.subscribe_flagging.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - flag
+id: flagging.subscribe_flagging
+field_name: subscribe_flagging
+entity_type: flagging
+type: entity_reference
+settings:
+  target_type: flagging
+module: core
+locked: true
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/message_subscribe_email/message_subscribe_email.install
+++ b/message_subscribe_email/message_subscribe_email.install
@@ -5,6 +5,9 @@
  * Install hooks for the message_subscribe_email module.
  */
 
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
+
 /**
  * Implements hook_install().
  *
@@ -43,6 +46,42 @@ function message_subscribe_email_install() {
         $flag->setThirdPartySetting('message_subscribe_ui', 'view_name', $view_name);
         $flag->save();
       }
+    }
+  }
+}
+
+/**
+ * Add an entity reference to the original subscribe flagging.
+ */
+function message_subscribe_email_update_8100() {
+  FieldStorageConfig::create([
+    'entity_type' => 'flagging',
+    'field_name' => 'subscribe_flagging',
+    'type' => 'entity_reference',
+    'settings' => [
+      'target_type' => 'flagging',
+    ],
+    'locked' => TRUE,
+  ])->setCardinality(1)->save();
+
+  $emailPrefix = \Drupal::config('message_subscribe_email.settings')->get('flag_prefix') . '_';
+  $flags = \Drupal::entityTypeManager()->getStorage('flag')->loadMultiple();
+  foreach ($flags as $flag) {
+    if (strpos($flag->id(), $emailPrefix) === 0) {
+      FieldConfig::create([
+        'entity_type' => 'flagging',
+        'bundle' => $flag->id(),
+        'field_name' => 'subscribe_flagging',
+        'type' => 'entity_reference',
+        'cardinality' => 1,
+      ])
+        ->setLabel('Subscription flagging')
+        ->setDescription('The subscribe flagging that this is tied to.')
+        ->setRequired(TRUE)
+        ->setSetting('target_type', 'flagging')
+        ->setSetting('handler', 'default')
+        ->setSetting('handler_settings', [])
+        ->save();
     }
   }
 }

--- a/message_subscribe_email/message_subscribe_email.module
+++ b/message_subscribe_email/message_subscribe_email.module
@@ -7,12 +7,9 @@
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\EntityTypeInterface;
-use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\field\Entity\FieldConfig;
-use Drupal\field\Entity\FieldStorageConfig;
+use Drupal\flag\FlaggingInterface;
 use Drupal\flag\FlagInterface;
 
 /**
@@ -136,7 +133,7 @@ function message_subscribe_email_message_subscribe_admin_settings_form_submit(ar
 /**
  * Implements hook_ENTITY_TYPE_presave().
  */
-function message_subscribe_email_flagging_presave(EntityInterface $entity) {
+function message_subscribe_email_flagging_presave(FlaggingInterface $entity) {
   $subscribePrefix = \Drupal::config('message_subscribe.settings')->get('flag_prefix') . '_';
   $emailPrefix = \Drupal::config('message_subscribe_email.settings')->get('flag_prefix') . '_';
 
@@ -146,9 +143,9 @@ function message_subscribe_email_flagging_presave(EntityInterface $entity) {
     $bundle = str_replace($emailPrefix, $subscribePrefix, $entity->bundle());
     $result = $storage->getQuery()
       ->condition('flag_id', $bundle)
-      ->condition('flagged_entity__target_id', $entity->flagged_entity->entity->id())
-      ->condition('flagged_entity__target_type', $entity->flagged_entity->entity->getEntityTypeId())
-      ->condition('uid', $entity->uid->target_id)
+      ->condition('flagged_entity__target_id', $entity->getFlaggableId())
+      ->condition('flagged_entity__target_type', $entity->getFlaggableType())
+      ->condition('uid', $entity->getOwnerId())
       ->execute();
     if (!empty($result)) {
       $entity->subscribe_flagging->target_id = reset($result);

--- a/message_subscribe_email/message_subscribe_email.module
+++ b/message_subscribe_email/message_subscribe_email.module
@@ -7,8 +7,12 @@
 
 use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\EntityTypeInterface;
+use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Session\AccountInterface;
+use Drupal\field\Entity\FieldConfig;
+use Drupal\field\Entity\FieldStorageConfig;
 use Drupal\flag\FlagInterface;
 
 /**
@@ -79,8 +83,8 @@ function message_subscribe_email_message_subscribe_get_subscribers_alter(array &
       ->condition('flag_id', $flag_ids, 'IN')
       ->condition('uid', array_keys($uids), 'IN')
       // Ensure to grab the correct flagging.
-      ->condition('entity_type', $entity_type)
-      ->condition('entity_id', $entity_ids, 'IN')
+      ->condition('flagged_entity__target_type', $entity_type)
+      ->condition('flagged_entity__target_id', $entity_ids, 'IN')
       ->groupBy('uid')
       ->execute()
       ->fetchAllAssoc('uid');
@@ -127,4 +131,27 @@ function message_subscribe_email_message_subscribe_admin_settings_form_submit(ar
     ->getEditable('message_subscribe_email.settings')
     ->set('flag_prefix', $form_state->getValue('message_subscribe_email_flag_prefix'))
     ->save();
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_presave().
+ */
+function message_subscribe_email_flagging_presave(EntityInterface $entity) {
+  $subscribePrefix = \Drupal::config('message_subscribe.settings')->get('flag_prefix') . '_';
+  $emailPrefix = \Drupal::config('message_subscribe_email.settings')->get('flag_prefix') . '_';
+
+  // Automatically set the reference to the subscribe flagging on creation.
+  if ($entity->isNew() && strpos($entity->bundle(), $emailPrefix) === 0) {
+    $storage = \Drupal::entityTypeManager()->getStorage('flagging');
+    $bundle = str_replace($emailPrefix, $subscribePrefix, $entity->bundle());
+    $result = $storage->getQuery()
+      ->condition('flag_id', $bundle)
+      ->condition('flagged_entity__target_id', $entity->flagged_entity->entity->id())
+      ->condition('flagged_entity__target_type', $entity->flagged_entity->entity->getEntityTypeId())
+      ->condition('uid', $entity->uid->target_id)
+      ->execute();
+    if (!empty($result)) {
+      $entity->subscribe_flagging->target_id = reset($result);
+    }
+  }
 }

--- a/message_subscribe_email/message_subscribe_email.post_update.php
+++ b/message_subscribe_email/message_subscribe_email.post_update.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @file
+ * Post update hook impllementations for Message Subscribe Email.
+ */
+
+/**
+ * Populate the new entity reference field.
+ */
+function message_subscribe_email_post_update_flagging_field(&$sandbox) {
+  $subscribePrefix = \Drupal::config('message_subscribe.settings')->get('flag_prefix') . '_';
+  $emailPrefix = \Drupal::config('message_subscribe_email.settings')->get('flag_prefix') . '_';
+  $storage = \Drupal::entityTypeManager()->getStorage('flagging');
+
+  $ids = $storage->getQuery()
+    ->condition('flag_id', $emailPrefix . '%', 'LIKE')
+    ->notExists('subscribe_flagging')
+    ->range(0, 100)
+    ->execute();
+
+  if (!isset($sandbox['current'])) {
+    $sandbox['current'] = 0;
+    $sandbox['max'] = $storage->getQuery()
+      ->condition('flag_id', $emailPrefix . '%', 'LIKE')
+      ->notExists('subscribe_flagging')
+      ->count()
+      ->execute();
+  }
+
+  foreach ($ids as $id) {
+    $sandbox['current']++;
+    $flagging = $storage->load($id);
+    $bundle = str_replace($emailPrefix, $subscribePrefix, $flagging->bundle());
+    $flaggedEntity = $flagging->flagged_entity->entity;
+
+    // Clean up any flaggings where the flagged entity no longer exists.
+    if (empty($flaggedEntity)) {
+      $flagging->delete();
+      $sandbox['deleted']++;
+      continue;
+    }
+
+    // Look up the corresponding subscribe flagging.
+    $result = $storage->getQuery()
+      ->condition('flag_id', $bundle)
+      ->condition('flagged_entity__target_id', $flaggedEntity->id())
+      ->condition('flagged_entity__target_type', $flaggedEntity->getEntityTypeId())
+      ->condition('uid', $flagging->uid->target_id)
+      ->execute();
+
+    // Populate the new field, if it could be found.
+    if (!empty($result)) {
+      $flagging->subscribe_flagging->target_id = reset($result);
+      $flagging->save();
+    }
+    // Otherwise, clean up the rogue email flag. It can't exist without its
+    // subscribe counterpart.
+    else {
+      $flagging->delete();
+      $sandbox['deleted']++;
+    }
+  }
+
+  $sandbox['#finished'] = empty($sandbox['max']) ? 1 : ($sandbox['current'] / $sandbox['max']);
+  if ($sandbox['#finished'] >= 1) {
+    return t('Updated @updated flagging items and deleted @deleted orphaned flagging items.', ['@updated' => $sandbox['max'], '@deleted' => $sandbox['deleted']]);
+  }
+  elseif (function_exists('drush_print')) {
+    drush_print('Completed ' . $sandbox['current'] . ' / ' . $sandbox['max'] . ' (' . number_format($sandbox['current'] / $sandbox['max'] * 100, 2) . '%)');
+  }
+}


### PR DESCRIPTION
Nothing currently ties the "subscribe" flagging directly to the "email" flagging, which makes Views relationships between the two not possible out of the box. This adds an actual reference to the "email" flagging.

**IMPORTANT:** This is not ready for merge yet. It's written with the assumption that the work from (https://www.drupal.org/node/2678756) has been incorporated, so this will not work properly as-is. I'm just running into time constraints and want to get something out there in case someone else has bandwidth.