### PR TITLE
Take the flag status into account with the subscriptions.

### DIFF
--- a/message_subscribe_ui/src/Controller/SubscriptionController.php
+++ b/message_subscribe_ui/src/Controller/SubscriptionController.php
@@ -92,9 +92,15 @@ class SubscriptionController extends ControllerBase {
    */
   public function tabAccess(AccountInterface $user, FlagInterface $flag = NULL) {
     if (!$flag) {
-      // We are inside /message-subscribe so get the first flag.
+      // We are inside /message-subscribe so get the first enabled flag.
       $flags = $this->subscribers->getFlags();
-      $flag = reset($flags);
+      foreach ($flags as $_flag) {
+        if ($_flag->status()) {
+          // Fetch the first enabled flag.
+          $flag = $_flag;
+          break;
+        }
+      }
     }
 
     if (!$flag) {
@@ -144,13 +150,25 @@ class SubscriptionController extends ControllerBase {
    */
   public function tab(UserInterface $user, FlagInterface $flag = NULL) {
     if (!$flag) {
-      // We are inside /message-subscribe so get the first flag.
+      // We are inside /message-subscribe so get the first enabled flag.
       $flags = $this->subscribers->getFlags();
-      $flag = reset($flags);
+      foreach ($flags as $_flag) {
+        if ($_flag->status()) {
+          // Fetch the first enabled flag.
+          $flag = $_flag;
+          break;
+        }
+      }
     }
 
     $view = $this->getView($user, $flag);
     $result = $view->preview();
+
+    // Add contextual links to the view for developer purposes.
+    $result['#view']->element['#view_id'] = $view->id();
+    $result['#view']->element['#view_display_show_admin_links'] = $view->getShowAdminLinks();
+    $result['#view']->element['#view_display_plugin_id'] = $view->display_handler->getPluginId();
+    views_add_contextual_links($result['#view']->element, 'view', $view->current_display);
 
     // Add cache tags for this flag and view.
     $result['#cache']['tags'] = $flag->getCacheTags() + $view->getCacheTags();

--- a/message_subscribe_ui/src/Plugin/Derivative/MessageSubscribeUiLocalTask.php
+++ b/message_subscribe_ui/src/Plugin/Derivative/MessageSubscribeUiLocalTask.php
@@ -46,6 +46,10 @@ class MessageSubscribeUiLocalTask extends DeriverBase implements ContainerDerive
 
     $first = TRUE;
     foreach ($this->subscribers->getFlags() as $flag) {
+      if (!$flag->status()) {
+        // Ignore disabled flags.
+        continue;
+      }
       $this->derivatives[$flag->id()] = [
         'title' => $flag->label(),
         // First route gets the same route name as the parent (in order to


### PR DESCRIPTION
Closes #122 

Attached static patch for local composer deployment: [122-message_subscribe-use-flag-status-1.patch](https://github.com/Gizra/message_subscribe/files/11373437/122-message_subscribe-use-flag-status-1.patch)
